### PR TITLE
Framed thread pool utilization benchmark hacking

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/common/util/concurrent/ThreadPoolUtilizationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/common/util/concurrent/ThreadPoolUtilizationBenchmark.java
@@ -9,14 +9,11 @@
 
 package org.elasticsearch.benchmark.common.util.concurrent;
 
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.TaskExecutionTimeTrackingEsThreadPoolExecutor;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -24,95 +21,80 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 1, time = 10, timeUnit = TimeUnit.SECONDS)
-@BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Threads(12)
+@Warmup(iterations = 3, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 600, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
 @Fork(1)
-@State(Scope.Thread)
 public class ThreadPoolUtilizationBenchmark {
 
-    @Param({ "false", "true" })
-    private boolean trackUtilization;
+    @Param({ "0", "100", "1000" })
+    private int callIntervalTicks;
 
-    @Param({ "4", "8", "16" })
-    private int poolSize;
-
-    @Param({ "1000000" })
-    private int tasksNum;
-
-    @Param({ "10" }) // 10ms is aggressive interval, it increases frame updates on FramedTimeTracker, normally we run at 30/60
-    // seconds
+    /**
+     * This makes very little difference, all the overhead is in the synchronization
+     */
+    @Param({ "10" })
     private int utilizationIntervalMs;
 
-    private EsThreadPoolExecutor executor;
+    @State(Scope.Thread)
+    public static class TaskState {
+        boolean running = false;
 
-    private EsThreadPoolExecutor newExecutor(boolean tracking) {
-        var conf = EsExecutors.TaskTrackingConfig.builder();
-        if (tracking) {
-            conf.trackExecutionTime(0.3).trackUtilization(Duration.ofMillis(utilizationIntervalMs));
+        boolean shouldStart() {
+            return (running = running == false);
         }
-        return EsExecutors.newFixed(
-            "bench",
-            poolSize,
-            tasksNum,
-            Executors.defaultThreadFactory(),
-            new ThreadContext(Settings.EMPTY),
-            conf.build()
-        );
     }
+
+    private TaskExecutionTimeTrackingEsThreadPoolExecutor.FramedTimeTracker timeTracker;
 
     @Setup
     public void setup() {
-        if (trackUtilization) {
-            var exec = newExecutor(true);
-            if (exec instanceof TaskExecutionTimeTrackingEsThreadPoolExecutor trackingExecutor) {
-                if (trackingExecutor.trackingConfig().trackUtilization() == false) {
-                    throw new IllegalStateException("utilization tracking must be enabled");
-                } else {
-                    executor = trackingExecutor;
-                }
-            } else {
-                throw new IllegalStateException("must be tracking executor");
-            }
-        } else {
-            var exec = newExecutor(false);
-            if (exec instanceof TaskExecutionTimeTrackingEsThreadPoolExecutor) {
-                throw new IllegalStateException("must be non-tracking executor");
-            }
-            executor = exec;
-        }
-    }
-
-    @TearDown
-    public void tearDown() throws InterruptedException {
-        executor.shutdown();
-        executor.awaitTermination(0, TimeUnit.MILLISECONDS);
+        timeTracker = new TaskExecutionTimeTrackingEsThreadPoolExecutor.FramedTimeTracker(
+            TimeUnit.MILLISECONDS.toNanos(utilizationIntervalMs),
+            System::nanoTime
+        );
     }
 
     @Benchmark
-    public void run(Blackhole bh) throws InterruptedException {
-        var completedTasks = new CountDownLatch(tasksNum);
-        for (var i = 0; i < tasksNum; i++) {
-            executor.execute(() -> {
-                // busy cycles for cpu
-                var r = 0;
-                for (var j = 0; j < 1000; j++) {
-                    r += j * 2;
-                }
-                bh.consume(r);
-                completedTasks.countDown();
-            });
+    public void baseline() {
+        Blackhole.consumeCPU(callIntervalTicks);
+    }
+
+    @Group("ReadAndWrite")
+    @Benchmark
+    public void startAndStopTasks(TaskState state) {
+        Blackhole.consumeCPU(callIntervalTicks);
+        if (state.shouldStart()) {
+            timeTracker.startTask();
+        } else {
+            timeTracker.endTask();
         }
-        completedTasks.await();
+    }
+
+    @Benchmark
+    @Group("ReadAndWrite")
+    public void readPrevious(Blackhole blackhole) {
+        Blackhole.consumeCPU(callIntervalTicks);
+        blackhole.consume(timeTracker.previousFrameTime());
+    }
+
+    @Benchmark
+    @Group("JustWrite")
+    public void startAndStopTasksOnly(TaskState state) {
+        Blackhole.consumeCPU(callIntervalTicks);
+        if (state.shouldStart()) {
+            timeTracker.startTask();
+        } else {
+            timeTracker.endTask();
+        }
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/common/util/concurrent/ThreadPoolUtilizationBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/common/util/concurrent/ThreadPoolUtilizationBenchmark.java
@@ -30,13 +30,13 @@ import java.util.concurrent.TimeUnit;
 @Threads(12)
 @Warmup(iterations = 3, time = 200, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 600, timeUnit = TimeUnit.MILLISECONDS)
-@BenchmarkMode(Mode.SampleTime)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 @Fork(1)
 public class ThreadPoolUtilizationBenchmark {
 
-    @Param({ "0", "100", "1000" })
+    @Param({ "0", "10000", "100000" })
     private int callIntervalTicks;
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -257,7 +257,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
      *
      * Can be extended to remember multiple past frames.
      */
-    static class FramedTimeTracker {
+    public static class FramedTimeTracker {
         final long interval;
         private final Supplier<Long> timeNow;
         long ongoingTasks;
@@ -266,7 +266,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
         long previousTime;
 
         // for testing
-        FramedTimeTracker(long intervalNano, Supplier<Long> timeNow) {
+        public FramedTimeTracker(long intervalNano, Supplier<Long> timeNow) {
             assert intervalNano > 0;
             this.interval = intervalNano;
             this.timeNow = timeNow;
@@ -278,7 +278,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
             this.timeNow = System::nanoTime;
         }
 
-        synchronized void updateFrame() {
+        public synchronized void updateFrame() {
             updateFrame0(timeNow.get());
         }
 
@@ -310,7 +310,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
          * Start tracking new task, assume that task runs indefinitely, or at least till end of frame.
          * If task finishes sooner than end of interval {@link FramedTimeTracker#endTask()} will deduct remaining time.
          */
-        synchronized void startTask() {
+        public synchronized void startTask() {
             var now = timeNow.get();
             updateFrame0(now);
             currentTime += (currentFrame + 1) * interval - now;
@@ -320,7 +320,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
         /**
          * Stop task tracking. We already assumed that task runs till end of frame, here we deduct not used time.
          */
-        synchronized void endTask() {
+        public synchronized void endTask() {
             var now = timeNow.get();
             updateFrame0(now);
             currentTime -= (currentFrame + 1) * interval - now;
@@ -330,7 +330,7 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
         /**
          * Returns previous frame total execution time.
          */
-        synchronized long previousFrameTime() {
+        public synchronized long previousFrameTime() {
             updateFrame0(timeNow.get());
             return previousTime;
         }


### PR DESCRIPTION
I micro-ized the benchmark to try and see what effect concurrency had on the time taken to call `startTask`, `endTask` and `previousFrameTime` concurrently from multiple threads.

Play around with 
```
 ./gradlew -p benchmarks run --args 'ThreadPoolUtilizationBenchmark -t $NUM_THREADS'
```

I think it looks very cheap. If you turn on sampling you see some outliers in the order of 10ms with 12 threads.

Also the amount of contention is probably a lot more than what we'd see in the real world. I tried to add some "work" in between calls, that's what `callIntervalTicks` does. But even worst case we're only adding in 0.2ms work between calls.

I'm not sure what are the largest core counts we see but it probably makes sense to see what happens on a bigger machine, perhaps increasing `callIntervalTicks` to something representative (you can see how long it takes with `baseline`)

(12-thread run on my machine, you have to deduct the baseline for the corresponding `callIntervalTicks`)

```
Benchmark                                                      (callIntervalTicks)  (utilizationIntervalMs)  Mode  Cnt    Score    Error  Units
ThreadPoolUtilizationBenchmark.JustWrite                                         0                       10  avgt    5    1.819 ±  0.126  us/op
ThreadPoolUtilizationBenchmark.JustWrite                                     10000                       10  avgt    5   20.762 ±  0.927  us/op
ThreadPoolUtilizationBenchmark.JustWrite                                    100000                       10  avgt    5  202.935 ± 10.831  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite                                      0                       10  avgt    5    0.939 ±  0.252  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:readPrevious                         0                       10  avgt    5    1.097 ±  0.387  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:startAndStopTasks                    0                       10  avgt    5    0.780 ±  0.160  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite                                  10000                       10  avgt    5   20.605 ±  0.838  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:readPrevious                     10000                       10  avgt    5   20.518 ±  1.397  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:startAndStopTasks                10000                       10  avgt    5   20.693 ±  0.632  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite                                 100000                       10  avgt    5  201.309 ±  8.873  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:readPrevious                    100000                       10  avgt    5  200.402 ±  9.548  us/op
ThreadPoolUtilizationBenchmark.ReadAndWrite:startAndStopTasks               100000                       10  avgt    5  202.216 ± 11.474  us/op
ThreadPoolUtilizationBenchmark.baseline                                          0                       10  avgt    5    0.002 ±  0.001  us/op
ThreadPoolUtilizationBenchmark.baseline                                      10000                       10  avgt    5   20.078 ±  0.845  us/op
ThreadPoolUtilizationBenchmark.baseline                                     100000                       10  avgt    5  201.026 ± 11.471  us/op
```

You can also run for specific `callIntervalTicks`. e.g.
```
./gradlew -p benchmarks run --args 'ThreadPoolUtilizationBenchmark -t 12 -pcallIntervalTicks=1000000'
```